### PR TITLE
修复长轮询出现ESOCKETTIMEDOUT的问题

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -118,8 +118,8 @@ export class Common {
         this.options.Signature = this.factorySignature(params);
         const args = this.getArgs();
         return new Promise((resolve, reject) => {
-            request.post(this.protocol + this.uri + this.path, {
-                timeout: 2000,
+            request.post(this.protocol + this.uri + this.path, 
+                timeout: (args.pollingWaitSeconds) ? args.pollingWaitSeconds * 1000 + 1000 : 2000,
                 form: args
             }, (error, response, body) => {
                 try {

--- a/src/common.ts
+++ b/src/common.ts
@@ -118,7 +118,7 @@ export class Common {
         this.options.Signature = this.factorySignature(params);
         const args = this.getArgs();
         return new Promise((resolve, reject) => {
-            request.post(this.protocol + this.uri + this.path, 
+            request.post(this.protocol + this.uri + this.path, {
                 timeout: (args.pollingWaitSeconds) ? args.pollingWaitSeconds * 1000 + 1000 : 2000,
                 form: args
             }, (error, response, body) => {


### PR DESCRIPTION
common的request里限制了timeout为2000ms，会导致调用receiveMessage接口并使用长轮询时报ESOCKETTIMEDOUT错误
+ 1000ms 是为了加上网络带来的延迟，避免ESOCKETTIMEDOUT错误
直接用args.pollingWaitSeconds * 1000的话长轮询到{$pollingWaitSeconds}秒时会报ESOCKETTIMEDOUT