### PR TITLE
fix: 默认的超时时间太短

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -133,7 +133,7 @@ export class Common {
     this.options.Timestamp = Math.floor(new Date().getTime() / 1000);
     this.options.Signature = this.factorySignature(this.getSignParams());
     const args = this.getArgs();
-    let timeout = 10000;
+    let timeout = 20000;
     if (args.pollingWaitSeconds) {
       timeout = args.pollingWaitSeconds * 1000 + 1000;
     }


### PR DESCRIPTION
默认的超时时间为 10s。而如果请求 `receiveMessage` 和 `batchReceiveMessage` 接口没有消息，CMQ 默认会等待 15s 获取新消息，这导致会频繁的超时错误